### PR TITLE
Fixed type in allow script

### DIFF
--- a/zerotier_allow.py
+++ b/zerotier_allow.py
@@ -29,8 +29,8 @@ r = requests.get('https://my.zerotier.com/api/network/%s/member/%s' % (
 
 data = r.json()
 
-if data['config']['authorized'] != "true":
-    data['config']['authorized'] = "true"
+if data['config']['authorized'] != True:
+    data['config']['authorized'] = True
 
     r = requests.post('https://my.zerotier.com/api/network/%s/member/%s' % (
                                                                            NETWORK,


### PR DESCRIPTION
It looks like the API for zero tier became more strict with the types allowed in the JSON.